### PR TITLE
Deprecates 'host' parameter in HTTP client methods

### DIFF
--- a/src/extractor/extractors/animepahe.nim
+++ b/src/extractor/extractors/animepahe.nim
@@ -189,7 +189,7 @@ proc get_m3u8_data(url: string, page: XmlNode) : array[8, string] =
 method get*(ex: AnimepaheEX, format: ExFormatData) : MediaFormatData =
   ex.info("Get Format Information")
   let
-    format_page = ex.connection.req(format.format_identifier, host="kwik.cx").to_selector()
+    format_page = ex.connection.req(format.format_identifier).to_selector()
     m3u8_data = format.format_identifier.get_m3u8_data(format_page)
 
   result.video = "https://vault-$vault.$host.top/stream/$vault/$index/$m3u8_id/uwu.m3u8" % m3u8_data

--- a/src/extractor/extractors/kickass.nim
+++ b/src/extractor/extractors/kickass.nim
@@ -4,7 +4,7 @@ import
 import
   htmlentity, sugar, json,
   options, strutils, sequtils,
-  marshal, oids, os
+  marshal
 
 import
   http/[client, response],
@@ -57,7 +57,7 @@ method formats(ex: KickassEX; url: string) : seq[ExFormatData] =
     return
 
   let
-    iframePage = ex.connection.req(host=detectHost(iframeUrl), url=iframeUrl)
+    iframePage = ex.connection.req(url=iframeUrl)
     iframeData = iframePage.to_readable().getBetween("props=\"", "\" ssr")
     formatData = iframeData.encode().parseJson()
 

--- a/src/extractor/extractors/otakudesu.nim
+++ b/src/extractor/extractors/otakudesu.nim
@@ -141,7 +141,7 @@ method get*(ex: OtakudesuEX, data: ExFormatData) : MediaFormatData =
     of sPdrain :
       video = iframeUrl
     else :
-      response = ex.connection.req(iframeUrl, mthod = HttpGet, host = "desustream.info")
+      response = ex.connection.req(iframeUrl, mthod = HttpGet)
       video = response.to_selector().select("source")[0].attr("src")
 
     let

--- a/src/http/client.nim
+++ b/src/http/client.nim
@@ -92,7 +92,6 @@ proc newHttpConnection*(host: string, ua: string, headers: Option[JsonNode] = no
     base_headers.add ("Accept-Encoding", "gzip")
 
   base_headers.add(("Accept", join(accept, ";")))
-  base_headers.add(("Host", host))
   cptr.logMode = mode
 
   let
@@ -170,12 +169,9 @@ proc jsonToForm*(j: JsonNode): string {.deprecated: "use http/utils instead".} =
 
   result = parts.join("&")
 
-proc reqq*(client: HttpClient, url: string, mthod: HttpMethod, payload: string, host: string = ""): Response =
+proc reqq*(client: HttpClient, url: string, mthod: HttpMethod, payload: string): Response =
   var
     newHeader: seq[(string, string)]
-  
-  if host.len > 0:
-    newHeader.add(("Host", host))
 
   let
     withPayload = payload != "" and payload != "{}"
@@ -205,6 +201,9 @@ proc reqq*(client: HttpClient, url: string, mthod: HttpMethod, payload: string, 
       url, mthod
     )
 
+proc reqq*(client: HttpClient, url: string, mthod: HttpMethod, payload: string, host: string): Response {.deprecated: "Param 'host' is deprecated".} =
+  reqq(client, url, mthod, payload)
+
 proc extractCookie(cookies: string, cookie: string) : string =
   for line in cookies.split("\n"):
     let cookieValue = line.split(";")[0].strip()
@@ -221,7 +220,6 @@ proc req*(
   url: string,
   mthod: HttpMethod = HttpGet,
   save_cookie: bool = true,
-  host: string = "",
   payload: string = "",
   useCache: bool = false
 ): Response {.gcsafe.} =
@@ -232,11 +230,11 @@ proc req*(
   proc loadContent() : Response =
     connection.info(url)
     try:
-      return connection.client.reqq(url, mthod, payload, host)
+      return connection.client.reqq(url, mthod, payload)
     except ProtocolError:
       connection.info("Renew Http Client")
       connection.reNewClient()
-      return connection.client.reqq(url, mthod, payload, host)
+      return connection.client.reqq(url, mthod, payload)
 
   if useCache and mthod == HttpGet :
     if connection.cache.has(url) :
@@ -260,13 +258,32 @@ proc req*(
   url: string,
   mthod: HttpMethod = HttpGet,
   save_cookie: bool = true,
-  host: string = "",
+  host: string,
+  payload: string = "",
+  useCache: bool = false
+): Response {.deprecated: "Param 'host' is deprecated".} =
+  req(connection, url, mthod, save_cookie, payload, useCache)
+
+proc req*(
+  connection: HttpConnection,
+  url: string,
+  mthod: HttpMethod = HttpGet,
+  save_cookie: bool = true,
   useCache: bool = false,
   payload: JsonNode
 ): Response {.gcsafe.} =
-  req(connection, url, mthod, save_cookie, host, $payload, useCache)
+  req(connection, url, mthod, save_cookie, $payload, useCache)
 
-export HttpConnection, Response, HttpMethod
+proc req*(
+  connection: HttpConnection,
+  url: string,
+  mthod: HttpMethod = HttpGet,
+  save_cookie: bool = true,
+  host: string,
+  useCache: bool = false,
+  payload: JsonNode
+): Response {.deprecated: "Param 'host' is deprecated".} =
+  req(connection, url, mthod, saveCookie, $payload, useCache)
 
 proc close*(connection: HttpConnection) =  
   # Stop
@@ -276,3 +293,5 @@ proc close*(connection: HttpConnection) =
   # Set to nill
   connection.log = nil
   connection.client = nil
+
+export HttpConnection, Response, HttpMethod


### PR DESCRIPTION
Removes the use of the 'Host' header in HTTP client methods, simplifying the API. Marks methods with the 'host' parameter as deprecated to encourage the transition to the updated interface. Improves maintainability by aligning methods with modern HTTP practices.

Updates related procedural calls to reflect the removal of the 'host' parameter, while providing backward compatibility with deprecated overloads.