### PR TITLE
Auto detect format.

### DIFF
--- a/src/app/stream/general_act.nim
+++ b/src/app/stream/general_act.nim
@@ -1,9 +1,10 @@
 import ../tui
 from tui/utils import waitFor
 
-import extractor/all
-import player/all
-import marshal, options
+import
+  extractor/all, player/all, media/format
+import
+  marshal, options
 
 type
   StreamSession* = tuple[
@@ -11,7 +12,8 @@ type
     anime: AnimeData,
     player: Player,
     episodes: seq[EpisodeData],
-    episodeIndex: int
+    episodeIndex: int,
+    selectedFormat: Option[FormatIdentity] = none(FormatIdentity)
   ]  
 
   StreamRoute = Route[StreamSession]  
@@ -41,8 +43,11 @@ proc realWatch(route: StreamRoute) =
     let sub = subtitles.get.ask()
     player.watch(media, some sub)    
 
-  else:
-    player.watch(media)
+  if route.session.selectedFormat.isNone:
+    route.session.selectedFormat = block:
+      mediaFormat.title.detectFormat.some
+
+  player.watch(media)
 
 proc selectAndPlay(route: StreamRoute) =
   let
@@ -55,7 +60,7 @@ proc selectAndPlay(route: StreamRoute) =
     route.error("No format available")    
     return
 
-  let mediaFormat = listFormat.ask("Select Format")
+  let mediaFormat = ex.ask(listFormat, route.session.selectedFormat)
   route.data = $$mediaFormat
   route.realWatch()
 

--- a/src/app/stream/general_act.nim
+++ b/src/app/stream/general_act.nim
@@ -13,7 +13,8 @@ type
     player: Player,
     episodes: seq[EpisodeData],
     episodeIndex: int,
-    selectedFormat: Option[FormatIdentity] = none(FormatIdentity)
+    selectedFormat: Option[FormatIdentity] = none(FormatIdentity),
+    autoSelectFormat = false
   ]  
 
   StreamRoute = Route[StreamSession]  
@@ -60,7 +61,16 @@ proc selectAndPlay(route: StreamRoute) =
     route.error("No format available")    
     return
 
-  let mediaFormat = ex.ask(listFormat, route.session.selectedFormat)
+  var mediaFormat: ExFormatData
+  
+  if ses.autoSelectFormat:
+    mediaFormat = findMatch(listFormat, ses.selectedFormat)
+  else:
+    mediaFormat = listFormat.ask("Select Format")
+
+  ses.selectedFormat = some detectFormat mediaFormat.title
+  ses.autoSelectFormat = false
+
   route.data = $$mediaFormat
   route.realWatch()
 
@@ -71,6 +81,11 @@ proc askEpisodeIdx(route: StreamRoute) =
 
 proc nextEpisode(route: StreamRoute) =
   route.session.episodeIndex += 1
+  route.session.autoSelectFormat = route.session.selectedFormat.isSome()
+
+  if route.session.autoSelectFormat:
+    route.selectAndPlay()
+
   route.setTitle()
   
 proc prevEpisode(route: StreamRoute) =

--- a/src/extractor/all.nim
+++ b/src/extractor/all.nim
@@ -3,6 +3,7 @@ import
   tables,
   types,
   strutils,
+  options,
   extractors/[
     animepahe,
     kuramanime,
@@ -13,7 +14,8 @@ import
   ]
 
 import
-  ../tui/[ask, logger]
+  ../tui/[ask, logger],
+  media/format
 
 type
   ExtractorInitProc = proc(ex: var BaseExtractor) {.gcsafe.}
@@ -75,6 +77,14 @@ proc ask*(ex: BaseExtractor, ad: AnimeData) : tuple[index: int, episodes: seq[Ep
   index = listEpisode.find(episode)
 
   return (index: index, episodes: listEpisode)  
+
+proc ask*(ex: BaseExtractor; formats: seq[ExFormatData]; prevSelectedFormat: Option[FormatIdentity] = none(FormatIdentity)): ExFormatData =
+  if prevSelectedFormat.isSome:
+    for format in formats:
+      if prevSelectedFormat.get == detectFormat(format.title):
+        return format
+
+  formats.ask("Select Format")    
 
 export
   BaseExtractor,

--- a/src/extractor/all.nim
+++ b/src/extractor/all.nim
@@ -86,6 +86,14 @@ proc ask*(ex: BaseExtractor; formats: seq[ExFormatData]; prevSelectedFormat: Opt
 
   formats.ask("Select Format")    
 
+proc findMatch*(listFormat: seq[ExFormatData]; prevSelectedFormat: Option[FormatIdentity]) : ExFormatData =
+  if prevSelectedFormat.isSome:
+    for fmt in listFormat:
+      if detectFormat(fmt.title) == prevSelectedFormat.get:
+        return fmt
+  
+  listFormat.ask("Select Format")
+
 export
   BaseExtractor,
   AnimeData,

--- a/src/languages.nim
+++ b/src/languages.nim
@@ -1,8 +1,9 @@
 import
-  tui/ask, strutils
+  tui/ask, strutils, sugar, sequtils
 
 type
   Languages* = enum
+    laUnknown = "unkown",
     laId = "indonesian,id",
     laSu = "sundanese,su"
     laEn = "english,en",
@@ -66,3 +67,19 @@ proc getLang*(lang: string) : Languages =
   for la in Languages:
     if lang == $la:
       return la
+
+proc detectLang*(sentence: string) : Languages = 
+  for la in Languages:
+    let
+      whiteList = ($la).split(",")
+      kalimat = sentence
+        .replace("[")
+        .replace("]")
+        .replace("(")
+        .replace(")")
+        .replace("")
+
+    if kalimat.splitWhitespace.map(word => whiteList.contains word.toLower).contains(true):
+      return la
+  
+  Languages.laUnknown

--- a/src/media/format.nim
+++ b/src/media/format.nim
@@ -1,5 +1,11 @@
 import
-  types, std/re, strutils
+  types, std/re, strutils, languages
+
+type FormatIdentity* = tuple[
+  res: MediaResolution,
+  ext: MediaExt,
+  lang: Languages,
+]
 
 proc detectResolution*(name: string) : MediaResolution =
   const
@@ -20,6 +26,11 @@ proc detectExt*(name: string) : MediaExt =
   if name.contains(".m3u8"):
     return extM3u8
   MediaExt.extNone
+
+proc detectFormat*(title: string) : FormatIdentity =
+  result.res = title.detectResolution()
+  result.ext = title.detectExt()
+  result.lang = title.detectLang()
 
 export
   MediaResolution, MediaExt

--- a/src/media/format.nim
+++ b/src/media/format.nim
@@ -1,0 +1,25 @@
+import
+  types, std/re, strutils
+
+proc detectResolution*(name: string) : MediaResolution =
+  const
+    badResolution = @[$480, $520, $360]
+    goodResolution = @[$720, $1080]
+
+  let containResolution = name.findAll(re"\d+")
+
+  for res in containResolution:
+    if badResolution.contains(res):
+      return rBad
+    elif goodResolution.contains(res):
+      return rGood
+
+proc detectExt*(name: string) : MediaExt =
+  if name.endsWith(".mp4"):
+    return extMp4
+  if name.contains(".m3u8"):
+    return extM3u8
+  MediaExt.extNone
+
+export
+  MediaResolution, MediaExt

--- a/src/media/format.nim
+++ b/src/media/format.nim
@@ -10,7 +10,8 @@ type FormatIdentity* = tuple[
 proc detectResolution*(name: string) : MediaResolution =
   const
     badResolution = @[$480, $520, $360]
-    goodResolution = @[$720, $1080]
+    goodResolution = @[$720]
+    bestResolution = @[$1080]
 
   let containResolution = name.findAll(re"\d+")
 
@@ -19,6 +20,8 @@ proc detectResolution*(name: string) : MediaResolution =
       return rBad
     elif goodResolution.contains(res):
       return rGood
+    elif bestResolution.contains(res):
+      return rBest
 
 proc detectExt*(name: string) : MediaExt =
   if name.endsWith(".mp4"):

--- a/src/media/types.nim
+++ b/src/media/types.nim
@@ -29,7 +29,7 @@ type
     subtitle* : Option[MediaSubtitle] = none(MediaSubtitle)
     headers*: Option[MediaHttpHeader] = none(MediaHttpHeader)  
 
-proc detectResolution*(name: string) : MediaResolution =
+proc detectResolution*(name: string) : MediaResolution {.deprecated: "Use media/resolution.detectResolution instead".} =
   const
     badResolution = @[$480, $360]
     goodResolution = @[$720, $1080]

--- a/src/media/types.nim
+++ b/src/media/types.nim
@@ -21,7 +21,7 @@ type
     extNone, extMp4, extM3u8
 
   MediaResolution* = enum
-    rBad, rGood
+    rBad, rGood, rBest
 
   MediaFormatData* = object of RootObj
     video*: string


### PR DESCRIPTION
### Use Cases
* Automatic format selection for streaming and downloading. No more repeated user input
* Improved version of `detectResolution()`

### Changes
* `StreamSession` structure. `selectedFormat: Option[FormatIdentity]` added.
* Mark `media/types.detectResolution` as deprecated.

### Main Usage
```nim
const yahh = isMainModule

when yahh:
  proc compare(t1, t2: string): bool =
    t1.detectFormat() == t2.detectFormat()

  block bener:
    assert compare("[SubsPlease] Slow Loop - 01 (540p) [4ABB7C1F].mkv", "[SubsPlease] Slow Loop - 02 (540p) [ABCDEFG].mkv")
    assert compare("Pahe, 720p, Indonesian", "Pahe, 720, id")
    assert compare("[pahe] Slow Loop - 02 (540p) [4ABB7C1F].mp4", "[pahe] Slow Loop - 03 (540p) [4ABB7C1F].mp4")
  block salah:
    assert not compare("Pahe, 720p, Indonesian.mkv", "Pahe, 720, English.mp4") # Beda Ekstensi
    assert not compare("Pahe, 720p, Indonesian", "Pahe, 720, English") # Beda Bahasa
    assert not compare("[SubsPlease] Slow Loop - 01 (540p) [4ABB7C1F].mkv", "[SubsPlease] Slow Loop - 02 (720p) [4ABB7C1F].mkv") # Beda Resolusi
    assert not compare("[SubsPlease] Slow Loop - 01 (540p) [4ABB7C1F].mkv", "[SubsPlease] Slow Loop - 02 (720p) EN [4ABB7C1F].mkv") # Beda Bahasa & Resolusi
```