### PR TITLE
ffmpegWrapper and refactor downloader to delegate to it

### DIFF
--- a/src/ffmpegWrapper.nim
+++ b/src/ffmpegWrapper.nim
@@ -1,0 +1,128 @@
+import
+  os,
+  options,
+  strutils,
+  sequtils,
+  tables
+
+import
+  ./process,
+  ./media/types,
+  ./tui/logger
+
+type
+  FfmpegWrapperOption* = tuple[
+    crf: int = 28,
+    fps: int = 25,
+    sub: bool = true,
+  ]
+
+  FfmpegWrapper* = ref object of CliApplication
+    outdir*: string
+    targetExt: string = "mp4"
+    options*: FfmpegWrapperOption
+
+proc newFfmpegWrapper*(outdir: string; options: FfmpegWrapperOption; logMode: WewboLogMode = mTui): FfmpegWrapper =
+  result = FfmpegWrapper(name: "ffmpeg", outdir: outdir, options: options, logMode: logMode).setUp()
+
+method failureHandler(ffmpeg: FfmpegWrapper, context: CLiError) =
+  raise newException(ValueError, "ffmpeg is not detected on your system.")
+
+method specialLineCb(cli: CliApplication) : SpecialLineProc =
+  (
+    proc (x: string) : bool =
+      x.contains("frame=")
+  )
+
+proc setHeader(ffmpeg: FfmpegWrapper, ty, val: string) =
+  let ngantukCok = {
+    "userAgent" : "User-Agent",
+    "referer" : "Referer",
+    "cookie" : "Cookie"
+  }.toTable
+
+  ffmpeg.addArg "-headers"
+  ffmpeg.addArg "$#: $#" % [ngantukCok[ty], val]
+
+proc setUpHeader(ffmpeg: FfmpegWrapper, headers: Option[MediaHttpHeader]) =
+  if headers.isNone :
+    return
+
+  for chi, no in headers.get.fieldPairs() :
+    if no != "" :
+      ffmpeg.setHeader(chi, no)
+
+proc setCodec(ffmpeg: FfmpegWrapper) =
+  ffmpeg.addArg "-vcodec"
+  ffmpeg.addArg "libx264"
+
+  ffmpeg.addArg "-crf"
+  ffmpeg.addArg $ffmpeg.options.crf
+
+  ffmpeg.addArg "-r"
+  ffmpeg.addArg $ffmpeg.options.fps
+
+proc setInput(ffmpeg: FfmpegWrapper, media: MediaFormatData) =
+  ffmpeg.addArg "-i"
+  ffmpeg.addArg media.video
+
+proc setOutput(ffmpeg: FfmpegWrapper, output: string) =
+  proc parseTargetFile(s: string) : string =
+    const nega = ["[", "]", "/", "\\", "?", ","]
+    result = s.replace(" ", "-")
+
+    for ne in nega:
+      result = result.replace(ne)
+
+  if not dirExists(ffmpeg.outdir) :
+    createDir(ffmpeg.outdir)
+
+  ffmpeg.addArg "$#.$#" % [ffmpeg.outdir / output.parseTargetFile(), ffmpeg.targetExt]
+
+proc handleSubtitle(ffmpeg: FfmpegWrapper, media: MediaFormatData) =
+  let
+    file = media.subtitle.get.url
+    tempFile = "wewbo_sub_file" & ".ass"
+
+  ffmpeg.addArg "-i"
+  ffmpeg.addArg file
+
+  ffmpeg.addArg "-c:s"
+  ffmpeg.addArg "ass"
+
+  ffmpeg.addArg tempFile
+
+  if ffmpeg.execute("Downloading Subtitle...") < 1 :
+    ffmpeg.setUpHeader(media.headers)
+    ffmpeg.setInput(media)
+    ffmpeg.addArg "-vf"
+    ffmpeg.addArg "ass=" & tempFile
+
+  else :
+    raise newException(ValueError, "Gagal Download Subtitle Jir")
+
+proc deleteTempFile {.nimcall.} = removeFile("wewbo_sub_file.ass")
+
+proc download*(ffmpeg: FfmpegWrapper, input: MediaFormatData, output: string) : int =
+  if input.subtitle.isSome and ffmpeg.options.sub:
+    ffmpeg.log.info("Extracting subtitle.")
+    ffmpeg.setUpHeader(input.headers)
+    ffmpeg.handleSubtitle(input)
+  else:
+    ffmpeg.setUpHeader(input.headers)
+    ffmpeg.setInput(input)
+
+  ffmpeg.setCodec()
+  ffmpeg.setOutput(output)
+
+  ffmpeg.execute("Downloading " & output, after = some(deleteTempFile))
+
+proc downloadAll*(ffmpeg: FfmpegWrapper, inputs: openArray[MediaFormatData], outputs: openArray[string]) : seq[int] =
+  assert inputs.len == outputs.len
+
+  ffmpeg.log.info("Downloading Options: " & $ffmpeg.options)
+  sleep(3_000)
+
+  for (input, output) in zip(inputs, outputs) :
+    result.add(
+      ffmpeg.download(input, output))

--- a/src/ffmpegWrapper.nim
+++ b/src/ffmpegWrapper.nim
@@ -34,6 +34,45 @@ method specialLineCb(cli: CliApplication) : SpecialLineProc =
       x.contains("frame=")
   )
 
+# Generic wrapper API
+proc resetArgs*(ffmpeg: FfmpegWrapper) =
+  ffmpeg.args = @[]
+
+proc addFlag*(ffmpeg: FfmpegWrapper; flag: string) =
+  ffmpeg.addArg(flag)
+
+proc addOption*(ffmpeg: FfmpegWrapper; key, value: string) =
+  ffmpeg.addArg(key)
+  ffmpeg.addArg(value)
+
+proc addInput*(ffmpeg: FfmpegWrapper; input: string) =
+  ffmpeg.addOption("-i", input)
+
+proc addOutput*(ffmpeg: FfmpegWrapper; output: string) =
+  ffmpeg.addArg(output)
+
+proc addVideoCodec*(ffmpeg: FfmpegWrapper; codec = "libx264") =
+  ffmpeg.addOption("-vcodec", codec)
+
+proc addCrf*(ffmpeg: FfmpegWrapper; crf: int) =
+  ffmpeg.addOption("-crf", $crf)
+
+proc addFps*(ffmpeg: FfmpegWrapper; fps: int) =
+  ffmpeg.addOption("-r", $fps)
+
+proc addFilter*(ffmpeg: FfmpegWrapper; value: string) =
+  ffmpeg.addOption("-vf", value)
+
+proc run*(ffmpeg: FfmpegWrapper; message = "Executing ffmpeg"; clearArgs = true) : int =
+  ffmpeg.execute(message = message, clearArgs = clearArgs)
+
+proc runWithArgs*(ffmpeg: FfmpegWrapper; args: openArray[string]; message = "Executing ffmpeg"; clearArgs = true) : int =
+  for arg in args:
+    ffmpeg.addArg(arg)
+
+  ffmpeg.run(message = message, clearArgs = clearArgs)
+
+# Media helpers for this project
 proc setHeader(ffmpeg: FfmpegWrapper, ty, val: string) =
   let ngantukCok = {
     "userAgent" : "User-Agent",
@@ -41,10 +80,9 @@ proc setHeader(ffmpeg: FfmpegWrapper, ty, val: string) =
     "cookie" : "Cookie"
   }.toTable
 
-  ffmpeg.addArg "-headers"
-  ffmpeg.addArg "$#: $#" % [ngantukCok[ty], val]
+  ffmpeg.addOption("-headers", "$#: $#" % [ngantukCok[ty], val])
 
-proc setUpHeader(ffmpeg: FfmpegWrapper, headers: Option[MediaHttpHeader]) =
+proc setUpMediaHeader*(ffmpeg: FfmpegWrapper, headers: Option[MediaHttpHeader]) =
   if headers.isNone :
     return
 
@@ -52,77 +90,70 @@ proc setUpHeader(ffmpeg: FfmpegWrapper, headers: Option[MediaHttpHeader]) =
     if no != "" :
       ffmpeg.setHeader(chi, no)
 
-proc setCodec(ffmpeg: FfmpegWrapper) =
-  ffmpeg.addArg "-vcodec"
-  ffmpeg.addArg "libx264"
+proc setDefaultEncoding*(ffmpeg: FfmpegWrapper) =
+  ffmpeg.addVideoCodec()
+  ffmpeg.addCrf(ffmpeg.options.crf)
+  ffmpeg.addFps(ffmpeg.options.fps)
 
-  ffmpeg.addArg "-crf"
-  ffmpeg.addArg $ffmpeg.options.crf
+proc setMediaInput*(ffmpeg: FfmpegWrapper, media: MediaFormatData) =
+  ffmpeg.addInput(media.video)
 
-  ffmpeg.addArg "-r"
-  ffmpeg.addArg $ffmpeg.options.fps
+proc sanitizeOutputName*(name: string) : string =
+  const nega = ["[", "]", "/", "\\", "?", ","]
+  result = name.replace(" ", "-")
 
-proc setInput(ffmpeg: FfmpegWrapper, media: MediaFormatData) =
-  ffmpeg.addArg "-i"
-  ffmpeg.addArg media.video
+  for ne in nega:
+    result = result.replace(ne)
 
-proc setOutput(ffmpeg: FfmpegWrapper, output: string) =
-  proc parseTargetFile(s: string) : string =
-    const nega = ["[", "]", "/", "\\", "?", ","]
-    result = s.replace(" ", "-")
-
-    for ne in nega:
-      result = result.replace(ne)
-
+proc buildTargetPath*(ffmpeg: FfmpegWrapper, output: string) : string =
   if not dirExists(ffmpeg.outdir) :
     createDir(ffmpeg.outdir)
 
-  ffmpeg.addArg "$#.$#" % [ffmpeg.outdir / output.parseTargetFile(), ffmpeg.targetExt]
+  "$#.$#" % [ffmpeg.outdir / output.sanitizeOutputName(), ffmpeg.targetExt]
 
-proc handleSubtitle(ffmpeg: FfmpegWrapper, media: MediaFormatData) =
-  let
-    file = media.subtitle.get.url
-    tempFile = "wewbo_sub_file" & ".ass"
+proc setMediaOutput*(ffmpeg: FfmpegWrapper, output: string) =
+  ffmpeg.addOutput(ffmpeg.buildTargetPath(output))
 
-  ffmpeg.addArg "-i"
-  ffmpeg.addArg file
-
-  ffmpeg.addArg "-c:s"
-  ffmpeg.addArg "ass"
-
-  ffmpeg.addArg tempFile
-
-  if ffmpeg.execute("Downloading Subtitle...") < 1 :
-    ffmpeg.setUpHeader(media.headers)
-    ffmpeg.setInput(media)
-    ffmpeg.addArg "-vf"
-    ffmpeg.addArg "ass=" & tempFile
-
-  else :
-    raise newException(ValueError, "Gagal Download Subtitle Jir")
+proc downloadSubtitleAsAss*(ffmpeg: FfmpegWrapper, subtitleUrl: string; tempFile = "wewbo_sub_file.ass") : int =
+  ffmpeg.runWithArgs([
+    "-i", subtitleUrl,
+    "-c:s", "ass",
+    tempFile
+  ], message = "Downloading Subtitle...")
 
 proc deleteTempFile {.nimcall.} = removeFile("wewbo_sub_file.ass")
 
-proc download*(ffmpeg: FfmpegWrapper, input: MediaFormatData, output: string) : int =
+proc downloadMedia*(ffmpeg: FfmpegWrapper, input: MediaFormatData, output: string) : int =
   if input.subtitle.isSome and ffmpeg.options.sub:
     ffmpeg.log.info("Extracting subtitle.")
-    ffmpeg.setUpHeader(input.headers)
-    ffmpeg.handleSubtitle(input)
-  else:
-    ffmpeg.setUpHeader(input.headers)
-    ffmpeg.setInput(input)
 
-  ffmpeg.setCodec()
-  ffmpeg.setOutput(output)
+    if ffmpeg.downloadSubtitleAsAss(input.subtitle.get.url) < 1:
+      ffmpeg.setUpMediaHeader(input.headers)
+      ffmpeg.setMediaInput(input)
+      ffmpeg.addFilter("ass=wewbo_sub_file.ass")
+    else:
+      raise newException(ValueError, "Gagal Download Subtitle Jir")
+  else:
+    ffmpeg.setUpMediaHeader(input.headers)
+    ffmpeg.setMediaInput(input)
+
+  ffmpeg.setDefaultEncoding()
+  ffmpeg.setMediaOutput(output)
 
   ffmpeg.execute("Downloading " & output, after = some(deleteTempFile))
 
-proc downloadAll*(ffmpeg: FfmpegWrapper, inputs: openArray[MediaFormatData], outputs: openArray[string]) : seq[int] =
+proc downloadMedias*(ffmpeg: FfmpegWrapper, inputs: openArray[MediaFormatData], outputs: openArray[string]) : seq[int] =
   assert inputs.len == outputs.len
 
   ffmpeg.log.info("Downloading Options: " & $ffmpeg.options)
   sleep(3_000)
 
   for (input, output) in zip(inputs, outputs) :
-    result.add(
-      ffmpeg.download(input, output))
+    result.add(ffmpeg.downloadMedia(input, output))
+
+# Backward-compatible aliases
+proc download*(ffmpeg: FfmpegWrapper, input: MediaFormatData, output: string) : int =
+  ffmpeg.downloadMedia(input, output)
+
+proc downloadAll*(ffmpeg: FfmpegWrapper, inputs: openArray[MediaFormatData], outputs: openArray[string]) : seq[int] =
+  ffmpeg.downloadMedias(inputs, outputs)

--- a/src/media/downloader.nim
+++ b/src/media/downloader.nim
@@ -13,7 +13,7 @@ proc newFfmpegDownloader*(outdir: string; options: FfmpegDownloaderOption; logMo
   ffw.newFfmpegWrapper(outdir = outdir, options = options, logMode = logMode)
 
 proc download*(ffmpeg: FfmpegDownloader, input: MediaFormatData, output: string) : int =
-  ffw.download(ffmpeg, input, output)
+  ffw.downloadMedia(ffmpeg, input, output)
 
 proc downloadAll*(ffmpeg: FfmpegDownloader, inputs: openArray[MediaFormatData], outputs: openArray[string]) : seq[int] =
-  ffw.downloadAll(ffmpeg, inputs, outputs)
+  ffw.downloadMedias(ffmpeg, inputs, outputs)

--- a/src/media/downloader.nim
+++ b/src/media/downloader.nim
@@ -1,147 +1,19 @@
-
-discard """
-  Pernah kah kau merasa? Jrek Jrek.
-  Saat. AAA. Bayangmupun tak mampu ku lihat lagiiiii
-"""
-
-discard """
-  ffmpeg -headers \"Referer: https://megacloud.blog/\" -i URL -vcodec libx264 -crf 28 -preset veryfast -r 25 output.mp4
-  ffmpeg -headers \"Referer: https://megacloud.blog/\" -i \"$#\" -vf \"ass=local_$#\" sj.mp4
-"""
+import
+  ../ffmpegWrapper as ffw
 
 import
-  os,
-  options,
-  strutils,
-  sequtils,
-  tables
-
-import  
-  ../process,
   ../media/types,
   ../tui/logger
 
 type
-  FfmpegDownloaderOption* = tuple[
-    crf: int = 28,
-    fps: int = 25,
-    sub: bool = true,
-  ]    
+  FfmpegDownloaderOption* = ffw.FfmpegWrapperOption
+  FfmpegDownloader* = ffw.FfmpegWrapper
 
-  FfmpegDownloader* = ref object of CliApplication
-    outdir*: string
-    targetExt: string = "mp4"
-    options*: FfmpegDownloaderOption
-
-proc newFfmpegDownloader*(outdir: string; options: FfmpegDownloaderOption) : FfmpegDownloader =
-  result = FfmpegDownloader(name: "ffmpeg", outdir: outdir, options: options).setUp()
-
-method failureHandler(ffmpeg: FfmpegDownloader, context: CLiError) =
-  raise newException(ValueError, "ffmpeg is not detected on your system.")
-
-method specialLineCb(cli: CliApplication) : SpecialLineProc =
-  (
-    proc (x: string) : bool =
-      x.contains("frame=")
-  )
-
-proc setHeader(ffmpeg: FfmpegDownloader, ty, val: string) =
-  let ngantukCok = {
-    "userAgent" : "User-Agent",
-    "referer" : "Referer",
-    "cookie" : "Cookie"
-  }.toTable
-
-  ffmpeg.addArg "-headers"
-  ffmpeg.addArg "$#: $#" % [ngantukCok[ty], val]
-
-proc setUpHeader(ffmpeg: FfmpegDownloader, headers: Option[MediaHttpHeader]) =
-  if headers.isNone :
-    return
-
-  for chi, no in headers.get.fieldPairs() :
-    if no != "" :
-      ffmpeg.setHeader(chi, no)
-
-proc setGatauIniApa(ffmpeg: FfmpegDownloader) =
-  # Vcodec
-  ffmpeg.addArg "-vcodec"
-  ffmpeg.addArg "libx264"
-
-  # Crf
-  ffmpeg.addArg "-crf"
-  ffmpeg.addArg $ffmpeg.options.crf
-
-  # Fps
-  ffmpeg.addArg "-r"
-  ffmpeg.addArg $ffmpeg.options.fps
-
-proc setInput(ffmpeg: FfmpegDownloader, media: MediaFormatData) =
-  ffmpeg.addArg "-i"
-  ffmpeg.addArg media.video
-
-proc setOutput(ffmpeg: FfmpegDownloader, output: string) =
-  proc parseTargetFile(s: string) : string = 
-    const nega = ["[", "]", "/", "\\", "?", ","]
-    result = s.replace(" ", "-")
-    
-    for ne in nega:
-      result = result.replace(ne)
-
-  if not dirExists(ffmpeg.outdir) :
-    createDir(ffmpeg.outdir)
-  
-  ffmpeg.addArg "$#.$#" % [ffmpeg.outdir / output.parseTargetFile(), ffmpeg.targetExt]
-
-proc handleSubtite(ffmpeg: FfmpegDownloader, media: MediaFormatData) =
-  # Download and convert the sub-file to ass format.
-  # Burn the subtitle.
-  let
-    file = media.subtitle.get.url
-    tempFile = "wewbo_sub_file" & ".ass"
-
-  # Set Input
-  ffmpeg.addArg "-i"
-  ffmpeg.addArg file
-
-  # Set Subtite Codec [ASS]
-  ffmpeg.addArg "-c:s"
-  ffmpeg.addArg "ass"
-
-  # Download
-  ffmpeg.addArg tempFile
-
-  if ffmpeg.execute("Downloading Subtitle...") < 1 :
-    ffmpeg.setUpHeader(media.headers)
-    ffmpeg.setInput(media)
-    ffmpeg.addArg "-vf"
-    ffmpeg.addArg "ass=" & tempFile
-
-  else :
-    raise newException(ValueError, "Gagal Download Subtitle Jir")
-
-proc deleteTempFile {.nimcall.} = removeFile("wewbo_sub_file.ass")
+proc newFfmpegDownloader*(outdir: string; options: FfmpegDownloaderOption; logMode: WewboLogMode = mTui) : FfmpegDownloader =
+  ffw.newFfmpegWrapper(outdir = outdir, options = options, logMode = logMode)
 
 proc download*(ffmpeg: FfmpegDownloader, input: MediaFormatData, output: string) : int =
-  if input.subtitle.isSome and ffmpeg.options.sub:
-    ffmpeg.log.info("Extracting subtitle.")
-    ffmpeg.setUpHeader(input.headers)
-    ffmpeg.handleSubtite(input)
-  else:  
-    ffmpeg.setUpHeader(input.headers)
-    ffmpeg.setInput(input)
-
-  ffmpeg.setGatauIniApa()
-  ffmpeg.setOutput(output)
-
-  ffmpeg.execute("Downloading " & output, after = some(deleteTempFile))
+  ffw.download(ffmpeg, input, output)
 
 proc downloadAll*(ffmpeg: FfmpegDownloader, inputs: openArray[MediaFormatData], outputs: openArray[string]) : seq[int] =
-  assert inputs.len == outputs.len
-
-  ffmpeg.log.info("Downloading Options: " & $ffmpeg.options)    
-  sleep(3_000)
-
-  for (input, output) in zip(inputs, outputs) :
-    result.add(
-      ffmpeg.download(input, output))
+  ffw.downloadAll(ffmpeg, inputs, outputs)


### PR DESCRIPTION
### Motivation

- Reduce duplication by centralizing ffmpeg command construction and execution into a single reusable module. 
- Improve separation of concerns so the downloader only orchestrates media inputs/outputs and delegates ffmpeg specifics. 
- Make it easier to reuse ffmpeg-related options and behavior elsewhere in the codebase.

### Description

- Add `src/ffmpegWrapper.nim` which implements `FfmpegWrapper`, `FfmpegWrapperOption`, and the ffmpeg command-building/execution helpers (headers, codec, inputs, outputs, subtitle handling, temp-file cleanup, and download helpers). 
- Refactor `src/media/downloader.nim` to import the wrapper as `../ffmpegWrapper as ffw` and to alias `FfmpegDownloaderOption` and `FfmpegDownloader` to the wrapper's types. 
- Replace duplicated ffmpeg setup code in `downloader.nim` with delegation calls to `ffw.newFfmpegWrapper`, `ffw.download`, and `ffw.downloadAll`. 
- Preserve prior subtitle extraction and temp-file cleanup behavior through the wrapper implementation and expose the same `download`/`downloadAll` API surface from the downloader module.

### Testing

- Project compiled successfully after the changes using the normal build (verified with `nimble build`).
- No automated tests were added or modified in this change; existing build-time checks passed after the refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee76ee935883309eff91e42f0c0d48)